### PR TITLE
feat(auth): migrate to OAuth 2.0 with DPoP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,443 +1,131 @@
-# Reference Implementation for Mastercard Promotions Digital Enablement
+# Promotions Digital Enablement API Reference Implementation
 
-[![](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/Mastercard/promotions-digital-enablement-reference-app/blob/master/LICENSE)
+## Frameworks / Libraries used
 
-## Table of Contents
-- [Overview](#overview)
-  * [Compatibility](#compatibility)
-  * [References](#references)
-- [Usage](#usage)
-  * [Prerequisites](#prerequisites)
-  * [Configuration](#configuration)
-    - [Authentication Mode Selection](#authentication-mode-selection)
-    - [OAuth 1.0a Setup](#oauth-1-setup)
-    - [OAuth 2.0 Setup](#oauth-2-setup)
-    - [Encryption and Decryption Configuration](#encryption-decryption-config)
-  * [Integrating with OpenAPI Generator](#integrating-with-openapi-generator)
-  * [Build and Execute](#build-and-execute)
-  * [Testing](#testing)
-- [Architecture](#architecture)
-  * [Authentication Flow](#authentication-flow)
-  * [Profile-Based Configuration](#profile-based-configuration)
-- [Use Cases](#use-cases)
-- [API Reference](#api-reference)
-  * [Authorization](#authorization)
-  * [Encryption and Decryption](#encryption-and-decryption)
-    - [Loading Encryption Certificate](#loading-encryption-certificate)
-    - [Loading Decryption Key](#loading-decryption-key)
-    - [Configuring JWE Instance](#configuring-jwe-instance)
-    - [Encrypting Entire Payloads](#encrypting-entire-payloads)
-    - [Decrypting Entire Payloads](#decrypting-entire-payloads)
-  * [Recommendation](#recommendation)
-- [Support](#support)
-- [License](#license)
+- [Spring Boot](https://spring.io/projects/spring-boot)
+- [Apache Maven](https://maven.apache.org/index.html)
+- [Mockito](https://site.mockito.org/)
 
-## Overview <a name="overview"></a>
-This is a reference application to demonstrate how Promotion Digital Enablement API can be used for the supported operations. Please see here for details on the API: [Mastercard Developers](https://developer.mastercard.com/rewards-progress/documentation).
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-This application supports **two authentication modes**:
-- **OAuth 1.0a** — Signature-based authentication using a consumer key and `.p12` signing key
-- **OAuth 2.0** — Token-based authentication with DPoP (Demonstrating Proof-of-Possession) using the FAPI 2.0 Security Profile
+## Requirements
+- JDK 17
+- Set up the [JAVA_HOME](https://explainjava.com/java-path/) environment variable to match the location of your Java installation.
+- Set up the [MAVEN_HOME](https://dzone.com/articles/installing-maven) environment variable to match the location of your Maven bin folder.
 
-Authentication mode is controlled via Spring Profiles (`oauth1` or `oauth2`).
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-### Compatibility <a name="compatibility"></a>
-* [Java 17](https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html) or later
-* [Spring Boot 2.6+](https://spring.io/projects/spring-boot)
-* [Apache Maven 3.3+](https://maven.apache.org/download.cgi)
+## Authentication Profiles
 
-### References <a name="references"></a>
-* [Mastercard's OAuth 1.0a Signer library](https://github.com/Mastercard/oauth1-signer-java)
-* [Mastercard's OAuth 2.0 Client library](https://github.com/Mastercard/oauth2-client-java)
-* [Using OAuth 1.0a to Access Mastercard APIs](https://developer.mastercard.com/platform/documentation/using-oauth-1a-to-access-mastercard-apis/)
-* [Using OAuth 2.0 to Access Mastercard APIs](https://developer.mastercard.com/platform/documentation/security-and-authentication/using-oauth-20/)
+This reference app supports two authentication strategies. The active profile is controlled by the `spring.profiles.active` property in `application.properties`.
 
-## Usage <a name="usage"></a>
-### Prerequisites <a name="prerequisites"></a>
-* [Mastercard Developers Account](https://developer.mastercard.com/dashboard) with access to Promotion Digital Enablement API
-* A text editor or IDE (IntelliJ IDEA recommended)
-* [Java 17+](https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html)
-* [Apache Maven 3.3+](https://maven.apache.org/download.cgi)
-* Set up the `JAVA_HOME` environment variable to match the location of your Java 17 installation.
+### OAuth 2.0 (Default — `oauth2`)
 
-### Configuration <a name="configuration"></a>
+Uses OAuth 2.0 with DPoP (Demonstrating Proof of Possession) and private key JWT authentication, following the FAPI 2.0 Security Profile. This is the **recommended and default** authentication method.
 
-#### Authentication Mode Selection <a name="authentication-mode-selection"></a>
-
-This application uses Spring Profiles to switch between OAuth 1.0a and OAuth 2.0. Set the active profile in `application.properties`:
-
-```properties
-# Options: oauth1, oauth2 (default)
-spring.profiles.active=oauth2
-```
-
----
-
-#### OAuth 1.0a Setup <a name="oauth-1-setup"></a>
-
-To use OAuth 1.0a authentication:
-
-1. Set `spring.profiles.active=oauth1` in `application.properties`
-2. Create a project on [Mastercard Developers](https://developer.mastercard.com/dashboard) and download the signing key (`.p12` file)
-3. Copy the `.p12` file to `src/main/resources/`
-4. Configure the following properties:
-
-```properties
-spring.profiles.active=oauth1
-
-# Path to PKCS12 keystore (.p12) file
-mastercard.api.key-file-path=src/main/resources/your-signing-key.p12
-
-# Consumer key from Mastercard Developers project page
-mastercard.api.consumer-key=your-consumer-key
-
-# Key alias (default: keyalias)
-mastercard.api.keystore-alias=keyalias
-
-# Keystore password (default: keystorepassword)
-mastercard.api.keystore-password=keystorepassword
-```
-
-**How it works:** The `ApiClientConfiguration` class (active with `oauth1` profile) uses `OkHttpOAuth1Interceptor` to sign each outgoing HTTP request with an OAuth 1.0a signature header.
-
----
-
-#### OAuth 2.0 Setup <a name="oauth-2-setup"></a>
-
-To use OAuth 2.0 authentication with DPoP:
-
-1. Set `spring.profiles.active=oauth2` in `application.properties`
-2. Create a project on [Mastercard Developers](https://developer.mastercard.com/dashboard) that has been upgraded to OAuth 2.0
-3. Download the signing key (`.p12` file) and note the **Client ID** and **Key ID (kid)** from the portal
-4. Copy the `.p12` file to `src/main/resources/`
-5. Configure the following properties:
-
+Required properties:
 ```properties
 spring.profiles.active=oauth2
 
-# Path to PKCS12 keystore (.p12) file (same key used for OAuth 1.0a signing)
-mastercard.api.key-file-path=src/main/resources/your-signing-key.p12
+mastercard.api.key-file-path=<path-to-signing-key.p12>
+mastercard.api.keystore-alias=<key-alias>
+mastercard.api.keystore-password=<keystore-password>
 
-# Key alias (default: keyalias)
-mastercard.api.keystore-alias=keyalias
-
-# Keystore password (default: keystorepassword)
-mastercard.api.keystore-password=keystorepassword
-
-# OAuth 2.0 Client ID from Mastercard Developers portal
-mastercard.api.oauth2.client.id=your-client-id
-
-# Key ID (kid) from Mastercard Developers portal
-mastercard.api.oauth2.kid=your-key-id
-
-# Token endpoint URL
+mastercard.api.oauth2.client.id=<your-oauth2-client-id>
+mastercard.api.oauth2.kid=<your-key-id>
 mastercard.api.oauth2.token.url=https://sandbox.api.mastercard.com/oauth/token
-
-# Issuer URL
 mastercard.api.oauth2.issuer.url=https://sandbox.api.mastercard.com
-
-# OAuth 2.0 scopes (comma-separated, from your project's scope list)
 mastercard.api.oauth2.scope=rewards-api-gateway:promotions-digital-enablement_read
 ```
 
-**How it works:** The `ApiClientOAuth2Configuration` class (active with `oauth2` profile) uses the `OAuth2Interceptor` from the `oauth2-client-java` library. It:
-1. Creates a signed JWT client assertion using your `.p12` private key
-2. Generates an ephemeral EC key pair for DPoP proof
-3. Requests an access token from the token endpoint
-4. Attaches both the `Authorization: DPoP <token>` and `DPoP` proof headers to each API request
-5. Caches tokens in-memory and refreshes them automatically when expired
+### OAuth 1.0a (`oauth1`)
 
-**Environment URLs:**
+Uses OAuth 1.0a with RSA-SHA256 signatures. This is an older authentication method.
 
-| Environment | Base Path | Token URL |
-|-------------|-----------|-----------|
-| Sandbox | `https://sandbox.api.mastercard.com/loyalty/rewards` | `https://sandbox.api.mastercard.com/oauth/token` |
-| Stage | `https://stage.api.mastercard.com/loyalty/rewards` | `https://stage.api.mastercard.com/oauth/token` |
-| Production | `https://api.mastercard.com/loyalty/rewards` | `https://api.mastercard.com/oauth/token` |
+To switch to this profile, update `spring.profiles.active=oauth1` in `application.properties` and provide the OAuth 1.0a-specific keys below.
 
----
+Required properties:
+```properties
+spring.profiles.active=oauth1
 
-#### Encryption and Decryption Configuration <a name="encryption-decryption-config"></a>
+mastercard.api.key-file=<path-to-signing-key.p12>
+mastercard.api.consumer-key=<your-consumer-key>
+mastercard.api.keystore-alias=<key-alias>
+mastercard.api.keystore-password=<keystore-password>
+```
 
-Both OAuth 1.0a and OAuth 2.0 modes support JWE payload encryption. Configure the following:
+The `mastercard.api.consumer-key` is only required for OAuth 1.0a. It can be found under Sandbox/Production Keys on your project page at the [Mastercard Developer Portal](https://developer.mastercard.com).
+
+----------------------------------------------------------------------------------------------------------------------------------------
+
+## Common Setup (Both Profiles)
+1. Open Mastercard Developers website and create an account at [Mastercard Developers](https://developer.mastercard.com).
+2. Create a new project [here](https://developer.mastercard.com/dashboard).
+3. Add the `Promotions Digital Enablement` API to your project and click continue.
+4. Configure project and click continue.
+5. Download Sandbox Signing Key.
+6. A `.p12` file is downloaded automatically. **Note**: On Safari, the file name will be `Unknown`. Rename it to a `.p12` extension.
+7. Copy the downloaded `.p12` file to `src/main/resources` folder in the code.
+8. Download Client Encryption Key.
+9. Copy the downloaded `.pem` file to `src/main/resources` folder in the code.
+10. Copy Client Encryption Key Fingerprint.
+
+### OAuth 2.0 Setup (Default)
+1. Open `src/main/resources/application.properties` and configure the following (OAuth 2.0 is already set as the default profile):
+    - `spring.profiles.active` = oauth2
+    - `mastercard.api.key-file-path` - Path to the `.p12` keystore file.
+    - `mastercard.api.keystore-alias` - Key alias. Default key alias for sandbox is `keyalias`.
+    - `mastercard.api.keystore-password` - Keystore password. Default keystore password for sandbox project is `keystorepassword`.
+    - `mastercard.api.oauth2.client.id` - OAuth 2.0 Client ID. Copy this from "Sandbox/Production Keys" on your project page.
+    - `mastercard.api.oauth2.kid` - Key ID. This is the same as the key alias. Default key alias for sandbox is `keyalias`.
+    - `mastercard.api.oauth2.token.url` - OAuth 2.0 token endpoint URL. For sandbox environment, use `https://sandbox.api.mastercard.com/oauth/token`.
+    - `mastercard.api.oauth2.issuer.url` - OAuth 2.0 issuer URL. For sandbox environment, use `https://sandbox.api.mastercard.com`.
+    - `mastercard.api.oauth2.scope` - OAuth 2.0 scopes. Use `rewards-api-gateway:promotions-digital-enablement_read`.
+2. Run `mvn clean install` from the root of the project directory.
+3. Run `mvn spring-boot:run` to start the project.
+4. Navigate to [http://localhost:8080/swagger-ui.html](http://localhost:8080/swagger-ui.html) in your browser.
+
+### OAuth 1.0a Setup
+1. Open `src/main/resources/application.properties` and configure the following:
+    - `spring.profiles.active` = oauth1
+    - `mastercard.api.key-file` - Path to the `.p12` keystore file.
+    - `mastercard.api.consumer-key` - OAuth 1.0a Consumer Key. Copy this from "Sandbox/Production Keys" on your project page.
+    - `mastercard.api.keystore-alias` - Key alias. Default key alias for sandbox is `keyalias`.
+    - `mastercard.api.keystore-password` - Keystore password. Default keystore password for sandbox project is `keystorepassword`.
+
+    **Note**: The `mastercard.api.consumer-key` is only required for OAuth 1.0a. It can be found under Sandbox/Production Keys on your project page at the Mastercard Developer Portal.
+2. Run `mvn clean install` from the root of the project directory.
+3. Run `mvn spring-boot:run` to start the project.
+4. Navigate to [http://localhost:8080/swagger-ui.html](http://localhost:8080/swagger-ui.html) in your browser.
+
+### Encryption and Decryption Configuration
+
+Both profiles require encryption/decryption configuration for payload security:
 
 ```properties
-# Encryption certificate (.pem) — for encrypting request payloads
-mastercard.api.encryption-certificate-file-path=src/main/resources/encryption-key.pem
-
-# Decryption key (.p12) — for decrypting response payloads
-mastercard.api.decryption-key-file-path=src/main/resources/decryption-key.p12
-
-# Decryption key alias
-mastercard.api.decryption-key-alias=keyalias
-
-# Decryption keystore password
-mastercard.api.decryption-keystore-password=keystorepassword
+mastercard.api.encryption-certificate-file=<path-to-encryption.pem>
+mastercard.api.encryption-key-fingerprint=<fingerprint>
+mastercard.api.decryption-key-file-path=<path-to-decryption.p12>
+mastercard.api.decryption-keystore-alias=<alias>
+mastercard.api.decryption-keystore-password=<password>
 ```
 
-Download these keys from the "API Keys" section of your project in the [Mastercard Developers](https://developer.mastercard.com/dashboard) portal:
-- **Client Encryption Key** — `.pem` file for encrypting payloads
-- **Mastercard Encryption Key** — `.p12` file for decrypting responses
+**Note**: Most of the fields in swagger are populated with example data. The fields that are left unpopulated should be populated with data specific to your promotions program.
 
----
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-### Integrating with OpenAPI Generator <a name="integrating-with-openapi-generator"></a>
-[OpenAPI Generator](https://github.com/OpenAPITools/openapi-generator) generates API client libraries from [OpenAPI Specs](https://github.com/OAI/OpenAPI-Specification).
-It provides generators and library templates for supporting multiple languages and frameworks.
+## Tutorial
 
-See also:
-* [OpenAPI Generator (maven Plugin)](https://mvnrepository.com/artifact/org.openapitools/openapi-generator-maven-plugin)
-* [OpenAPI Generator (executable)](https://mvnrepository.com/artifact/org.openapitools/openapi-generator-cli)
-* [CONFIG OPTIONS for java](https://github.com/OpenAPITools/openapi-generator/blob/master/docs/generators/java.md)
+A tutorial can be found [here](https://developer.mastercard.com/promotions-digital-enablement/documentation/tutorials-and-guides/) for setting up and using this service.
 
-#### OpenAPI Generator Plugin Configuration
-```xml
-<!-- https://mvnrepository.com/artifact/org.openapitools/openapi-generator-maven-plugin -->
-<plugin>
-    <groupId>org.openapitools</groupId>
-    <artifactId>openapi-generator-maven-plugin</artifactId>
-    <version>${openapi-generator.version}</version>
-    <executions>
-        <execution>
-            <id>Promotions Digital Enablement API Client</id>
-            <goals>
-                <goal>generate</goal>
-            </goals>
-            <configuration>
-                <inputSpec>${project.basedir}/src/main/resources/Promotions_Digital_Enablement-api-spec.yaml</inputSpec>
-                <generatorName>java</generatorName>
-                <library>okhttp-gson</library>
-                <generateApiTests>false</generateApiTests>
-                <generateModelTests>false</generateModelTests>
-                <configOptions>
-                    <sourceFolder>src/gen/main/java</sourceFolder>
-                    <dateLibrary>java8</dateLibrary>
-                </configOptions>
-            </configuration>
-        </execution>
-    </executions>
-</plugin>
-```
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-#### Generating The API Client Sources
-Now that you have all the dependencies you need, you can generate the sources. To do this, use one of the following two methods:
+## Service Documentation
 
-`Using IDE`
-* **Method 1**<br/>
-  In IntelliJ IDEA, open the Maven window **(View > Tool Windows > Maven)**. Click the icons `Reimport All Maven Projects` and `Generate Sources and Update Folders for All Projects`
+Promotions Digital Enablement service documentation can be found [here](https://developer.mastercard.com/promotions-digital-enablement/documentation/)
 
-* **Method 2**<br/>
-  In the same menu, navigate to the commands **({Project name} > Lifecycle)**, select `clean` and `compile` then click the icon `Run Maven Build`.
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-`Using Terminal`
-* Navigate to the root directory of the project within a terminal window and execute `mvn clean compile` command.
+## Contact us
 
-### Build and Execute <a name="build-and-execute"></a>
-Once you've added the correct properties, we can build the application. We can do this by navigating to the project's base directory from the terminal and running the following command:
-
-1. Run `mvn clean install` from the root of the project directory.
-2. Run `mvn spring-boot:run` to start the project.
-3. Navigate to [http://localhost:8080/swagger-ui/index.html](http://localhost:8080/swagger-ui/index.html) in your browser.
-
-### Testing <a name="testing"></a>
-
-#### Verify OAuth 2.0 Authentication
-
-Once the application is running with `spring.profiles.active=oauth2`, test with:
-
-```bash
-# List promotions (requires a valid rewardsCompanyId, programId, promotionId, or accountId)
-curl -X GET "http://localhost:8080/promotions?programId=YOUR_PROGRAM_ID" \
-  -H "accept: application/json"
-
-# Get promotion details
-curl -X GET "http://localhost:8080/promotions/{promotionId}/details?include_audience=false" \
-  -H "accept: application/json"
-
-# Search accounts (requires encrypted payload)
-curl -X POST "http://localhost:8080/accounts/searches" \
-  -H "Content-Type: application/json" \
-  -H "accept: application/json" \
-  -d '{"accountId": "your-account-id"}'
-```
-
-**Expected behavior:**
-- If authentication succeeds, you will receive a business-level response (200 or a business error like `INVALID_FIELD_PROMOTION_ID`)
-- If authentication fails, you will see errors like `invalid_client` or `client_assertion signature couldn't be verified`
-
-#### Verify OAuth 1.0a Authentication
-
-Switch to `spring.profiles.active=oauth1`, configure the consumer key and `.p12` file, then test with the same curl commands above.
-
-#### Common Errors
-
-| Error | Cause | Fix |
-|-------|-------|-----|
-| `invalid_client` / `client_assertion signature couldn't be verified` | `.p12` key doesn't match the client ID/kid | Ensure all credentials are from the same project |
-| `insufficient_scope` | Token scope doesn't match API requirements | Verify scopes in `application.properties` match your portal |
-| `FORBIDDEN` / `User does not have required permissions` | Client not authorized for the resource | Check your project has access to the specific programId/data |
-| `NoClassDefFoundError: tools/jackson/core/type/TypeReference` | Missing Jackson 3.x dependency | Ensure `jackson-databind:3.0.3` and `jackson-annotations:2.19.4` are in pom.xml |
-
----
-
-## Architecture <a name="architecture"></a>
-
-### Authentication Flow <a name="authentication-flow"></a>
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                    Profile: oauth1                                │
-├─────────────────────────────────────────────────────────────────┤
-│ Request → OkHttpJweEncryptionInterceptor (encrypt payload)      │
-│         → OkHttpOAuth1Interceptor (sign request)                │
-│         → Mastercard API                                        │
-└─────────────────────────────────────────────────────────────────┘
-
-┌─────────────────────────────────────────────────────────────────┐
-│                    Profile: oauth2                                │
-├─────────────────────────────────────────────────────────────────┤
-│ Request → OkHttpJweEncryptionInterceptor (encrypt payload)      │
-│         → OAuth2Interceptor (obtain token + DPoP proof)         │
-│         → HttpLoggingInterceptor (log request/response)         │
-│         → Mastercard API                                        │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-### Profile-Based Configuration <a name="profile-based-configuration"></a>
-
-```
-ApiClientProvider (interface)
-  └── BaseApiClientConfiguration (abstract - shared key loading)
-       ├── ApiClientConfiguration (@Profile("oauth1"))
-       │     └── Provides: apiClient, cryptoApiClient beans
-       └── ApiClientOAuth2Configuration (@Profile("oauth2"), @Primary)
-             └── Provides: apiClient, cryptoApiClient beans
-
-ApiClientResolver (resolves client based on active profile)
-```
-
-| Class | Profile | Description |
-|-------|---------|-------------|
-| `BaseApiClientConfiguration` | — | Abstract base; loads `.p12` signing key, builds base `ApiClient` |
-| `ApiClientConfiguration` | `oauth1` | Configures `OkHttpOAuth1Interceptor` for signature-based auth |
-| `ApiClientOAuth2Configuration` | `oauth2` | Configures `OAuth2Interceptor` with DPoP for token-based auth |
-| `ApiClientResolver` | — | Resolves the correct `ApiClient` based on active Spring profile |
-| `ApiClientProvider` | — | Interface defining `getApiClient()` and `createNewApiClient()` |
-
----
-
-## Swagger <a name="Swagger"></a>
-Navigate to [http://localhost:8080/swagger-ui/index.html](http://localhost:8080/swagger-ui/index.html) in your browser to access the following controllers:
-1. **AccountController**
-    - `POST /accounts/searches`
-2. **OptInController**
-    - `POST /promotion-activations`
-    - `GET /promotions`
-3. **PromotionDetailController**
-    - `GET /promotions/{id}/details`
-4. **ProgressController**
-    - `GET /promotion-progresses`
-5. **EventController**
-    - `GET /events`
-    - `POST /events`
-6. **AudienceController**
-    - `GET /audiences`
-    - `POST /audiences`
-    - `PUT /audiences/{id}`
-    - `DELETE /audiences/{id}`
-7. **TransactionController**
-    - `GET /transactions`
-
-## Use Cases <a name="use-cases"></a>
-Refer [Use Cases](https://developer.mastercard.com/rewards-progress/documentation/use-cases/) for more details.
-
-## API Reference <a name="api-reference"></a>
-Refer [Api Reference](https://developer.mastercard.com/rewards-progress/documentation/api-reference/) to develop a client application that consumes a RESTful Promotion Digital Enablement API with Spring Boot.
-
-### Authorization <a name="authorization"></a>
-The `com.mastercard.developer.interceptors` package provides request interceptor classes for configuring your API client. These classes handle adding the correct `Authorization` header before sending the request.
-
-- **OAuth 1.0a**: `OkHttpOAuth1Interceptor` — adds an `Authorization: OAuth ...` signature header
-- **OAuth 2.0**: `OAuth2Interceptor` — obtains a DPoP-bound access token and adds `Authorization: DPoP <token>` + `DPoP` proof headers
-
-### Encryption and Decryption <a name="encryption-and-decryption"></a>
-The `com.mastercard.developer.crypto.interceptor` package provides `OkHttpJweEncryptionInterceptor` that encrypts request payloads and decrypts response payloads using JWE (JSON Web Encryption).
-
-#### Loading Encryption Certificate <a name="loading-encryption-certificate"></a>
-
-A `Certificate` object can be created from a file by calling `EncryptionUtils.loadEncryptionCertificate`:
-```java
-Certificate encryptionCertificate = EncryptionUtils.loadEncryptionCertificate("<insert certificate file path>");
-```
-
-Supported certificate formats: PEM, DER.
-
-#### Loading Decryption Key <a name="loading-decryption-key"></a>
-
-##### From a PKCS#12 Key Store
-
-A `PrivateKey` object can be created from a PKCS#12 key store by calling `EncryptionUtils.loadDecryptionKey` the following way:
-```java
-PrivateKey decryptionKey = EncryptionUtils.loadDecryptionKey(
-                                    "<insert PKCS#12 key file path>",
-                                    "<insert key alias>",
-                                    "<insert key password>");
-```
-
-#### Configuring JWE Instance <a name="configuring-jwe-instance"></a>
-Use the `JweConfigBuilder` to create `JweConfig` instances. Example:
-```java
-JweConfig jweConfig = JweConfigBuilder.aJweEncryptionConfig()
-        .withEncryptionCertificate(certificate)
-        .withEncryptionPath("$", "$")
-        .withEncryptedValueFieldName("encryptedPayload")
-        .withDecryptionKey(decryptionKey)
-        .build();
-```
-
-#### Encrypting Entire Payloads <a name="encrypting-entire-payloads"></a>
-
-Example using the configuration [above](#configuring-jwe-instance):
-```java
-String payload = "{" +
-    "    \"sensitiveField1\": \"sensitiveValue1\"," +
-    "    \"sensitiveField2\": \"sensitiveValue2\"" +
-    "}";
-```
-
-Output:
-```json
-{
-    "encryptedPayload": "eyJhbGciOiJSU0EtT0(...)IsImVuYyI6IkEyNTifQ.OKOawDo13gRp2ojaHV7LFpZcg(...)VZKTyKOMTYUmKoTCVJRgckCL9kiMT03JGe.48V1_ALb6US04U3b.5eym8TW_c8SuK0ltJ3rpYI(...)7TALvtu6UG9oMo4vpzs9tX_EFShS8iB7j6ji.XFBoMYUZodetZdvTiFvSkQ"
-}
-```
-
-#### Decrypting Entire Payloads <a name="decrypting-entire-payloads"></a>
-
-Example using the configuration [above](#configuring-jwe-instance):
-```java
-String encryptedPayload = "{" +
-    "  \"encryptedPayload\": \"eyHhbGciOiJSU0EtT0F(...)BiYzQyTIyNTQ1ODgzNSJ9.VkO7N6gAptqoD7IQaK(...)ptYySP_TuvERby89DY1EezAm3A.qj6ISyzq1ASDJKD0.ENF7bUfBkoWAEYvk(...)o9JGMctx-PSdeVqwCQAVRNj0pYs1WjOp4UDbE4eEZIF6YA.Wc7ARH7R6sikpKzxET3MYA\" +
-    "}";
-```
-
-Output:
-```json
-{
-    "sensitiveField1": "sensitiveValue1",
-    "sensitiveField2": "sensitiveValue2"
-}
-```
-
-### Recommendation <a name="recommendation"></a>
-It is recommended to create an instance of `ApiClient` per thread in a multithreaded environment to avoid any potential issues.
-
-## Support <a name="support"></a>
-If you would like further information, please send an email to apisupport@mastercard.com
-
-## License <a name="license"></a>
-Copyright 2020 Mastercard
-
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
+Please send an email to [apisupport@mastercard.com]() with any questions or feedback you may have.

--- a/README.md
+++ b/README.md
@@ -9,72 +9,180 @@
 - [Usage](#usage)
   * [Prerequisites](#prerequisites)
   * [Configuration](#configuration)
+    - [Authentication Mode Selection](#authentication-mode-selection)
+    - [OAuth 1.0a Setup](#oauth-1-setup)
+    - [OAuth 2.0 Setup](#oauth-2-setup)
+    - [Encryption and Decryption Configuration](#encryption-decryption-config)
   * [Integrating with OpenAPI Generator](#integrating-with-openapi-generator)
   * [Build and Execute](#build-and-execute)
+  * [Testing](#testing)
+- [Architecture](#architecture)
+  * [Authentication Flow](#authentication-flow)
+  * [Profile-Based Configuration](#profile-based-configuration)
 - [Use Cases](#use-cases)
 - [API Reference](#api-reference)
   * [Authorization](#authorization)
   * [Encryption and Decryption](#encryption-and-decryption)
     - [Loading Encryption Certificate](#loading-encryption-certificate)
     - [Loading Decryption Key](#loading-decryption-key)
-    - [Configuring JWE Instance](#configuring-jwe-instance)  
+    - [Configuring JWE Instance](#configuring-jwe-instance)
     - [Encrypting Entire Payloads](#encrypting-entire-payloads)
     - [Decrypting Entire Payloads](#decrypting-entire-payloads)
-  * [Request Examples](#request-examples)
   * [Recommendation](#recommendation)
 - [Support](#support)
 - [License](#license)
 
 ## Overview <a name="overview"></a>
 This is a reference application to demonstrate how Promotion Digital Enablement API can be used for the supported operations. Please see here for details on the API: [Mastercard Developers](https://developer.mastercard.com/rewards-progress/documentation).
-This application illustrates connecting to the Promotion Digital Enablement API with encryption. To call these APIs, consumer key, .p12 files and encryption certs are required from your [Mastercard Developers](https://developer.mastercard.com/dashboard) project.
+
+This application supports **two authentication modes**:
+- **OAuth 1.0a** — Signature-based authentication using a consumer key and `.p12` signing key
+- **OAuth 2.0** — Token-based authentication with DPoP (Demonstrating Proof-of-Possession) using the FAPI 2.0 Security Profile
+
+Authentication mode is controlled via Spring Profiles (`oauth1` or `oauth2`).
 
 ### Compatibility <a name="compatibility"></a>
-* [Java 8](http://www.oracle.com/technetwork/java/javase/downloads/index.html) or later
+* [Java 17](https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html) or later
+* [Spring Boot 2.6+](https://spring.io/projects/spring-boot)
+* [Apache Maven 3.3+](https://maven.apache.org/download.cgi)
 
 ### References <a name="references"></a>
-* [Mastercard’s OAuth Signer library](https://github.com/Mastercard/oauth1-signer-java)
+* [Mastercard's OAuth 1.0a Signer library](https://github.com/Mastercard/oauth1-signer-java)
+* [Mastercard's OAuth 2.0 Client library](https://github.com/Mastercard/oauth2-client-java)
 * [Using OAuth 1.0a to Access Mastercard APIs](https://developer.mastercard.com/platform/documentation/using-oauth-1a-to-access-mastercard-apis/)
+* [Using OAuth 2.0 to Access Mastercard APIs](https://developer.mastercard.com/platform/documentation/security-and-authentication/using-oauth-20/)
 
 ## Usage <a name="usage"></a>
 ### Prerequisites <a name="prerequisites"></a>
 * [Mastercard Developers Account](https://developer.mastercard.com/dashboard) with access to Promotion Digital Enablement API
-* A text editor or IDE
-* [Spring Boot 2.2+](https://spring.io/projects/spring-boot)
+* A text editor or IDE (IntelliJ IDEA recommended)
+* [Java 17+](https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html)
 * [Apache Maven 3.3+](https://maven.apache.org/download.cgi)
-* Set up the `JAVA_HOME` environment variable to match the location of your Java installation.
+* Set up the `JAVA_HOME` environment variable to match the location of your Java 17 installation.
 
 ### Configuration <a name="configuration"></a>
-* Create an account at [Mastercard Developers](https://developer.mastercard.com/account/sign-up).  
-* Create a new project and add `Promotion Digital Enablement` API to your project.   
-* Configure project and download signing key. It will download the zip file.  
-* Select `.p12` files from zip and copy it to `src/main/resources` in the project folder.
-* Open `${project.basedir}/src/main/resources/application.properties` and configure below parameters.
-    
-    >**mastercard.api.base-path=https://sandbox.api.mastercard.com/loyalty/rewards**, its a static field, will be used as a host to make API calls.
-    
-    **Below properties will be required for authentication of API calls.**
-    
-    >**mastercard.api.key-file=**, this refers to .p12 file found in the signing key. Please place .p12 file at src\main\resources in the project folder and add classpath for .p12 file.
-    
-    >**mastercard.api.consumer-key=**, this refers to your consumer key. Copy it from "Keys" section on your project page in [Mastercard Developers](https://developer.mastercard.com/dashboard)
-      
-    >**mastercard.api.keystore-alias=keyalias**, this is the default value of key alias. If it is modified, use the updated one from keys section in [Mastercard Developers](https://developer.mastercard.com/dashboard).
-    
-    >**mastercard.api.keystore-password=keystorepassword**, this is the default value of key alias. If it is modified, use the updated one from keys section in [Mastercard Developers](https://developer.mastercard.com/dashboard).
 
-    **Below properties will be required to encrypt and decrypt the request and response payloads**
-    
-    >**mastercard.api.encryption-certificate-file=**, this is the path to certificate (.crt or .pem) file. Add classpath for file, after placing it at src\main\resources in the project folder. Download Encryption Key from "Client Encryption" section on your project page in [Mastercard Developers](https://developer.mastercard.com/dashboard)
-    
-    >**mastercard.api.decryption-key-file=**, this is your private key (.p12) file, required to decrypt a request. Add classpath for this file, after placing it at src\main\resources in the project folder.
-    
-    >**mastercard.api.decryption-key-alias=**, this is required to load your decryption private key.
+#### Authentication Mode Selection <a name="authentication-mode-selection"></a>
 
-    >**mastercard.api.decryption-keystore-password=**, this is required to load your decryption private key. 
+This application uses Spring Profiles to switch between OAuth 1.0a and OAuth 2.0. Set the active profile in `application.properties`:
+
+```properties
+# Options: oauth1, oauth2 (default)
+spring.profiles.active=oauth2
+```
+
+---
+
+#### OAuth 1.0a Setup <a name="oauth-1-setup"></a>
+
+To use OAuth 1.0a authentication:
+
+1. Set `spring.profiles.active=oauth1` in `application.properties`
+2. Create a project on [Mastercard Developers](https://developer.mastercard.com/dashboard) and download the signing key (`.p12` file)
+3. Copy the `.p12` file to `src/main/resources/`
+4. Configure the following properties:
+
+```properties
+spring.profiles.active=oauth1
+
+# Path to PKCS12 keystore (.p12) file
+mastercard.api.key-file-path=src/main/resources/your-signing-key.p12
+
+# Consumer key from Mastercard Developers project page
+mastercard.api.consumer-key=your-consumer-key
+
+# Key alias (default: keyalias)
+mastercard.api.keystore-alias=keyalias
+
+# Keystore password (default: keystorepassword)
+mastercard.api.keystore-password=keystorepassword
+```
+
+**How it works:** The `ApiClientConfiguration` class (active with `oauth1` profile) uses `OkHttpOAuth1Interceptor` to sign each outgoing HTTP request with an OAuth 1.0a signature header.
+
+---
+
+#### OAuth 2.0 Setup <a name="oauth-2-setup"></a>
+
+To use OAuth 2.0 authentication with DPoP:
+
+1. Set `spring.profiles.active=oauth2` in `application.properties`
+2. Create a project on [Mastercard Developers](https://developer.mastercard.com/dashboard) that has been upgraded to OAuth 2.0
+3. Download the signing key (`.p12` file) and note the **Client ID** and **Key ID (kid)** from the portal
+4. Copy the `.p12` file to `src/main/resources/`
+5. Configure the following properties:
+
+```properties
+spring.profiles.active=oauth2
+
+# Path to PKCS12 keystore (.p12) file (same key used for OAuth 1.0a signing)
+mastercard.api.key-file-path=src/main/resources/your-signing-key.p12
+
+# Key alias (default: keyalias)
+mastercard.api.keystore-alias=keyalias
+
+# Keystore password (default: keystorepassword)
+mastercard.api.keystore-password=keystorepassword
+
+# OAuth 2.0 Client ID from Mastercard Developers portal
+mastercard.api.oauth2.client.id=your-client-id
+
+# Key ID (kid) from Mastercard Developers portal
+mastercard.api.oauth2.kid=your-key-id
+
+# Token endpoint URL
+mastercard.api.oauth2.token.url=https://sandbox.api.mastercard.com/oauth/token
+
+# Issuer URL
+mastercard.api.oauth2.issuer.url=https://sandbox.api.mastercard.com
+
+# OAuth 2.0 scopes (comma-separated, from your project's scope list)
+mastercard.api.oauth2.scope=rewards-api-gateway:promotions-digital-enablement_read
+```
+
+**How it works:** The `ApiClientOAuth2Configuration` class (active with `oauth2` profile) uses the `OAuth2Interceptor` from the `oauth2-client-java` library. It:
+1. Creates a signed JWT client assertion using your `.p12` private key
+2. Generates an ephemeral EC key pair for DPoP proof
+3. Requests an access token from the token endpoint
+4. Attaches both the `Authorization: DPoP <token>` and `DPoP` proof headers to each API request
+5. Caches tokens in-memory and refreshes them automatically when expired
+
+**Environment URLs:**
+
+| Environment | Base Path | Token URL |
+|-------------|-----------|-----------|
+| Sandbox | `https://sandbox.api.mastercard.com/loyalty/rewards` | `https://sandbox.api.mastercard.com/oauth/token` |
+| Stage | `https://stage.api.mastercard.com/loyalty/rewards` | `https://stage.api.mastercard.com/oauth/token` |
+| Production | `https://api.mastercard.com/loyalty/rewards` | `https://api.mastercard.com/oauth/token` |
+
+---
+
+#### Encryption and Decryption Configuration <a name="encryption-decryption-config"></a>
+
+Both OAuth 1.0a and OAuth 2.0 modes support JWE payload encryption. Configure the following:
+
+```properties
+# Encryption certificate (.pem) — for encrypting request payloads
+mastercard.api.encryption-certificate-file-path=src/main/resources/encryption-key.pem
+
+# Decryption key (.p12) — for decrypting response payloads
+mastercard.api.decryption-key-file-path=src/main/resources/decryption-key.p12
+
+# Decryption key alias
+mastercard.api.decryption-key-alias=keyalias
+
+# Decryption keystore password
+mastercard.api.decryption-keystore-password=keystorepassword
+```
+
+Download these keys from the "API Keys" section of your project in the [Mastercard Developers](https://developer.mastercard.com/dashboard) portal:
+- **Client Encryption Key** — `.pem` file for encrypting payloads
+- **Mastercard Encryption Key** — `.p12` file for decrypting responses
+
+---
 
 ### Integrating with OpenAPI Generator <a name="integrating-with-openapi-generator"></a>
-[OpenAPI Generator](https://github.com/OpenAPITools/openapi-generator) generates API client libraries from [OpenAPI Specs](https://github.com/OAI/OpenAPI-Specification). 
+[OpenAPI Generator](https://github.com/OpenAPITools/openapi-generator) generates API client libraries from [OpenAPI Specs](https://github.com/OAI/OpenAPI-Specification).
 It provides generators and library templates for supporting multiple languages and frameworks.
 
 See also:
@@ -102,7 +210,7 @@ See also:
                 <generateApiTests>false</generateApiTests>
                 <generateModelTests>false</generateModelTests>
                 <configOptions>
-                    <sourceFolder>src/gen/java/main</sourceFolder>
+                    <sourceFolder>src/gen/main/java</sourceFolder>
                     <dateLibrary>java8</dateLibrary>
                 </configOptions>
             </configuration>
@@ -119,39 +227,141 @@ Now that you have all the dependencies you need, you can generate the sources. T
   In IntelliJ IDEA, open the Maven window **(View > Tool Windows > Maven)**. Click the icons `Reimport All Maven Projects` and `Generate Sources and Update Folders for All Projects`
 
 * **Method 2**<br/>
-  In the same menu, navigate to the commands **({Project name} > Lifecycle)**, select `clean` and `compile` then click the icon `Run Maven Build`. 
+  In the same menu, navigate to the commands **({Project name} > Lifecycle)**, select `clean` and `compile` then click the icon `Run Maven Build`.
 
 `Using Terminal`
-* Navigate to the root directory of the project within a terminal window and execute `./mvnw clean compile` command.
+* Navigate to the root directory of the project within a terminal window and execute `mvn clean compile` command.
 
 ### Build and Execute <a name="build-and-execute"></a>
-Once you’ve added the correct properties, we can build the application. We can do this by navigating to the project’s base directory from the terminal and running the following command
+Once you've added the correct properties, we can build the application. We can do this by navigating to the project's base directory from the terminal and running the following command:
 
 1. Run `mvn clean install` from the root of the project directory.
 2. Run `mvn spring-boot:run` to start the project.
 3. Navigate to [http://localhost:8080/swagger-ui/index.html](http://localhost:8080/swagger-ui/index.html) in your browser.
 
+### Testing <a name="testing"></a>
+
+#### Verify OAuth 2.0 Authentication
+
+Once the application is running with `spring.profiles.active=oauth2`, test with:
+
+```bash
+# List promotions (requires a valid rewardsCompanyId, programId, promotionId, or accountId)
+curl -X GET "http://localhost:8080/promotions?programId=YOUR_PROGRAM_ID" \
+  -H "accept: application/json"
+
+# Get promotion details
+curl -X GET "http://localhost:8080/promotions/{promotionId}/details?include_audience=false" \
+  -H "accept: application/json"
+
+# Search accounts (requires encrypted payload)
+curl -X POST "http://localhost:8080/accounts/searches" \
+  -H "Content-Type: application/json" \
+  -H "accept: application/json" \
+  -d '{"accountId": "your-account-id"}'
+```
+
+**Expected behavior:**
+- If authentication succeeds, you will receive a business-level response (200 or a business error like `INVALID_FIELD_PROMOTION_ID`)
+- If authentication fails, you will see errors like `invalid_client` or `client_assertion signature couldn't be verified`
+
+#### Verify OAuth 1.0a Authentication
+
+Switch to `spring.profiles.active=oauth1`, configure the consumer key and `.p12` file, then test with the same curl commands above.
+
+#### Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `invalid_client` / `client_assertion signature couldn't be verified` | `.p12` key doesn't match the client ID/kid | Ensure all credentials are from the same project |
+| `insufficient_scope` | Token scope doesn't match API requirements | Verify scopes in `application.properties` match your portal |
+| `FORBIDDEN` / `User does not have required permissions` | Client not authorized for the resource | Check your project has access to the specific programId/data |
+| `NoClassDefFoundError: tools/jackson/core/type/TypeReference` | Missing Jackson 3.x dependency | Ensure `jackson-databind:3.0.3` and `jackson-annotations:2.19.4` are in pom.xml |
+
+---
+
+## Architecture <a name="architecture"></a>
+
+### Authentication Flow <a name="authentication-flow"></a>
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    Profile: oauth1                                │
+├─────────────────────────────────────────────────────────────────┤
+│ Request → OkHttpJweEncryptionInterceptor (encrypt payload)      │
+│         → OkHttpOAuth1Interceptor (sign request)                │
+│         → Mastercard API                                        │
+└─────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────┐
+│                    Profile: oauth2                                │
+├─────────────────────────────────────────────────────────────────┤
+│ Request → OkHttpJweEncryptionInterceptor (encrypt payload)      │
+│         → OAuth2Interceptor (obtain token + DPoP proof)         │
+│         → HttpLoggingInterceptor (log request/response)         │
+│         → Mastercard API                                        │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Profile-Based Configuration <a name="profile-based-configuration"></a>
+
+```
+ApiClientProvider (interface)
+  └── BaseApiClientConfiguration (abstract - shared key loading)
+       ├── ApiClientConfiguration (@Profile("oauth1"))
+       │     └── Provides: apiClient, cryptoApiClient beans
+       └── ApiClientOAuth2Configuration (@Profile("oauth2"), @Primary)
+             └── Provides: apiClient, cryptoApiClient beans
+
+ApiClientResolver (resolves client based on active profile)
+```
+
+| Class | Profile | Description |
+|-------|---------|-------------|
+| `BaseApiClientConfiguration` | — | Abstract base; loads `.p12` signing key, builds base `ApiClient` |
+| `ApiClientConfiguration` | `oauth1` | Configures `OkHttpOAuth1Interceptor` for signature-based auth |
+| `ApiClientOAuth2Configuration` | `oauth2` | Configures `OAuth2Interceptor` with DPoP for token-based auth |
+| `ApiClientResolver` | — | Resolves the correct `ApiClient` based on active Spring profile |
+| `ApiClientProvider` | — | Interface defining `getApiClient()` and `createNewApiClient()` |
+
+---
+
 ## Swagger <a name="Swagger"></a>
-Navigate to [http://localhost:8080/swagger-ui/index.html](http://localhost:8080/swagger-ui/index.html) in your browser to access bellow controllers,
-1. AccountController
-    1. /accounts/searches
-2. OptInController
-    1. /promotion-activations
-    2. /promotions
-3. ProgressController
-    1. /promotion-progresses
+Navigate to [http://localhost:8080/swagger-ui/index.html](http://localhost:8080/swagger-ui/index.html) in your browser to access the following controllers:
+1. **AccountController**
+    - `POST /accounts/searches`
+2. **OptInController**
+    - `POST /promotion-activations`
+    - `GET /promotions`
+3. **PromotionDetailController**
+    - `GET /promotions/{id}/details`
+4. **ProgressController**
+    - `GET /promotion-progresses`
+5. **EventController**
+    - `GET /events`
+    - `POST /events`
+6. **AudienceController**
+    - `GET /audiences`
+    - `POST /audiences`
+    - `PUT /audiences/{id}`
+    - `DELETE /audiences/{id}`
+7. **TransactionController**
+    - `GET /transactions`
 
 ## Use Cases <a name="use-cases"></a>
 Refer [Use Cases](https://developer.mastercard.com/rewards-progress/documentation/use-cases/) for more details.
 
 ## API Reference <a name="api-reference"></a>
-Refer [Api Reference](https://developer.mastercard.com/rewards-progress/documentation/api-reference/) To develop a client application that consumes a RESTful Promotion Digital Enablement API with Spring Boot.
+Refer [Api Reference](https://developer.mastercard.com/rewards-progress/documentation/api-reference/) to develop a client application that consumes a RESTful Promotion Digital Enablement API with Spring Boot.
 
 ### Authorization <a name="authorization"></a>
-The `com.mastercard.developer.interceptors` package will provide you with some request interceptor classes you can use when configuring your API client. These classes will take care of adding the correct `Authorization` header before sending the request.
+The `com.mastercard.developer.interceptors` package provides request interceptor classes for configuring your API client. These classes handle adding the correct `Authorization` header before sending the request.
+
+- **OAuth 1.0a**: `OkHttpOAuth1Interceptor` — adds an `Authorization: OAuth ...` signature header
+- **OAuth 2.0**: `OAuth2Interceptor` — obtains a DPoP-bound access token and adds `Authorization: DPoP <token>` + `DPoP` proof headers
 
 ### Encryption and Decryption <a name="encryption-and-decryption"></a>
-The `com.mastercard.developer.interceptors` provides a class that you can use when configuring your API client. This class will take care of encrypting payload before sending the request and decrypting payload after receiving the response.
+The `com.mastercard.developer.crypto.interceptor` package provides `OkHttpJweEncryptionInterceptor` that encrypts request payloads and decrypts response payloads using JWE (JSON Web Encryption).
 
 #### Loading Encryption Certificate <a name="loading-encryption-certificate"></a>
 
@@ -169,8 +379,8 @@ Supported certificate formats: PEM, DER.
 A `PrivateKey` object can be created from a PKCS#12 key store by calling `EncryptionUtils.loadDecryptionKey` the following way:
 ```java
 PrivateKey decryptionKey = EncryptionUtils.loadDecryptionKey(
-                                    "<insert PKCS#12 key file path>", 
-                                    "<insert key alias>", 
+                                    "<insert PKCS#12 key file path>",
+                                    "<insert key alias>",
                                     "<insert key password>");
 ```
 
@@ -227,9 +437,7 @@ If you would like further information, please send an email to apisupport@master
 
 ## License <a name="license"></a>
 Copyright 2020 Mastercard
- 
+
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
- 
+
        http://www.apache.org/licenses/LICENSE-2.0
- 
-Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,8 @@
         <openapi-generator.version>7.12.0</openapi-generator.version>
         <oauth1-signer.version>1.5.3</oauth1-signer.version>
         <client-encryption.version>1.8.6</client-encryption.version>
-        <okhttp3.version>4.9.3</okhttp3.version>
+        <okhttp3.version>4.12.0</okhttp3.version>
+        <oauth2-client-java.version>1.0.2</oauth2-client-java.version>
         <swagger-parser.version>2.0.30</swagger-parser.version>
         <springfox.version>3.0.0</springfox.version>
         <commons-lang3.version>3.12.0</commons-lang3.version>
@@ -41,6 +42,13 @@
             <groupId>com.mastercard.developer</groupId>
             <artifactId>oauth1-signer</artifactId>
             <version>${oauth1-signer.version}</version>
+        </dependency>
+
+        <!-- OAuth 2.0 Client with DPoP support -->
+        <dependency>
+            <groupId>com.mastercard.developer</groupId>
+            <artifactId>oauth2-client-java</artifactId>
+            <version>${oauth2-client-java.version}</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.mastercard.developer/client-encryption -->

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,19 @@
             <version>${oauth2-client-java.version}</version>
         </dependency>
 
+        <!-- Jackson 3.x required by oauth2-client-java -->
+        <dependency>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>3.0.3</version>
+        </dependency>
+        <!-- jackson-databind 3.x requires jackson-annotations 2.19+ (for POJO Shape enum) -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.19.4</version>
+        </dependency>
+
         <!-- https://mvnrepository.com/artifact/com.mastercard.developer/client-encryption -->
         <dependency>
             <groupId>com.mastercard.developer</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -220,6 +220,7 @@
                             <configOptions>
                                 <sourceFolder>src/gen/main/java</sourceFolder>
                                 <dateLibrary>java8</dateLibrary>
+                                <disallowAdditionalPropertiesIfNotPresent>false</disallowAdditionalPropertiesIfNotPresent>
                             </configOptions>
                         </configuration>
                     </execution>

--- a/src/main/java/com/mastercard/developer/config/ApiClientConfiguration.java
+++ b/src/main/java/com/mastercard/developer/config/ApiClientConfiguration.java
@@ -4,76 +4,91 @@ import com.mastercard.developer.crypto.interceptor.OkHttpJweEncryptionIntercepto
 import com.mastercard.developer.encryption.JweConfig;
 import com.mastercard.developer.encryption.JweConfigBuilder;
 import com.mastercard.developer.interceptors.OkHttpOAuth1Interceptor;
-import com.mastercard.developer.utils.AuthenticationUtils;
 import com.mastercard.developer.utils.EncryptionUtils;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import okhttp3.OkHttpClient;
 import org.openapitools.client.ApiClient;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 import java.security.PrivateKey;
 import java.security.cert.Certificate;
 
 /**
- * This is ApiClient configuration, it will read properties from application.properties and create instance of ApiClient.
+ * OAuth 1.0a ApiClient configuration. Active when spring.profiles.active=oauth1.
  */
+@Profile("oauth1")
 @Slf4j
 @Configuration
-@EnableConfigurationProperties(MastercardProperties.class)
-public class ApiClientConfiguration {
+public class ApiClientConfiguration extends BaseApiClientConfiguration {
 
-    private final MastercardProperties mcProperties;
-    private final OkHttpOAuth1Interceptor okHttpOAuth1Interceptor;
+    @Value("${mastercard.api.consumer-key}")
+    private String consumerKey;
 
-    @Autowired
-    @SneakyThrows
-    public ApiClientConfiguration(MastercardProperties mcProperties) {
-        this.mcProperties = mcProperties;
-        PrivateKey signingKey = AuthenticationUtils.loadSigningKey(mcProperties.getKeyFile().getFile().getAbsolutePath(), mcProperties.getKeystoreAlias(), mcProperties.getKeystorePassword());
-        this.okHttpOAuth1Interceptor = new OkHttpOAuth1Interceptor(mcProperties.getConsumerKey(), signingKey);
+    @Value("${mastercard.api.encryption-certificate-file-path:#{null}}")
+    private String encryptionCertificateFilePath;
+
+    @Value("${mastercard.api.decryption-key-file-path:#{null}}")
+    private String decryptionKeyFilePath;
+
+    @Value("${mastercard.api.decryption-key-alias:#{null}}")
+    private String decryptionKeyAlias;
+
+    @Value("${mastercard.api.decryption-keystore-password:#{null}}")
+    private String decryptionKeystorePassword;
+
+    @Override
+    public ApiClient getApiClient() {
+        return createNewApiClient();
+    }
+
+    @Override
+    public ApiClient createNewApiClient() {
+        ApiClient apiClient = buildBaseApiClient();
+        try {
+            OkHttpClient.Builder okHttpClientBuilder = buildHttpClientBuilder(apiClient);
+            okHttpClientBuilder.addInterceptor(new OkHttpOAuth1Interceptor(consumerKey, loadSigningKey()));
+            return apiClient.setHttpClient(okHttpClientBuilder.build());
+        } catch (Exception e) {
+            log.error("Failed to initialize OAuth1 ApiClient: {}", e.getMessage());
+        }
+        return apiClient;
     }
 
     @Bean
     public ApiClient apiClient() {
-        ApiClient apiClient = newApiClient();
-        return apiClient.setHttpClient(apiClient.getHttpClient()
-                .newBuilder()
-                .addInterceptor(okHttpOAuth1Interceptor)
-                .build()
-        );
+        return createNewApiClient();
     }
 
     @Bean
-    @SneakyThrows
     public ApiClient cryptoApiClient() {
-        ApiClient cryptoApiClient = newApiClient();
+        ApiClient cryptoApiClient = buildBaseApiClient();
+        try {
+            OkHttpClient.Builder okHttpClientBuilder = buildHttpClientBuilder(cryptoApiClient);
 
-        Certificate certificate = EncryptionUtils.loadEncryptionCertificate(mcProperties.getEncryptionCertificateFile().getFile().getAbsolutePath());
-        PrivateKey decryptionKey = EncryptionUtils.loadDecryptionKey(mcProperties.getDecryptionKeyFile().getFile().getAbsolutePath(), mcProperties.getDecryptionKeyAlias(), mcProperties.getDecryptionKeystorePassword());
+            // Add JWE encryption if configured
+            if (encryptionCertificateFilePath != null && decryptionKeyFilePath != null) {
+                Certificate certificate = EncryptionUtils.loadEncryptionCertificate(encryptionCertificateFilePath);
+                PrivateKey decryptionKey = EncryptionUtils.loadDecryptionKey(
+                        decryptionKeyFilePath, decryptionKeyAlias, decryptionKeystorePassword);
 
-        JweConfig jweConfig = JweConfigBuilder.aJweEncryptionConfig()
-                .withEncryptionCertificate(certificate)
-                .withEncryptionPath("$", "$")
-                .withEncryptedValueFieldName("encryptedPayload")
-                .withDecryptionKey(decryptionKey)
-                .build();
+                JweConfig jweConfig = JweConfigBuilder.aJweEncryptionConfig()
+                        .withEncryptionCertificate(certificate)
+                        .withEncryptionPath("$", "$")
+                        .withEncryptedValueFieldName("encryptedPayload")
+                        .withDecryptionKey(decryptionKey)
+                        .build();
 
-        return cryptoApiClient.setHttpClient(cryptoApiClient.getHttpClient()
-                .newBuilder()
-                .addInterceptor(new OkHttpJweEncryptionInterceptor(jweConfig))
-                .addInterceptor(okHttpOAuth1Interceptor)
-                .build()
-        );
-    }
+                okHttpClientBuilder.addInterceptor(new OkHttpJweEncryptionInterceptor(jweConfig));
+            }
 
-    private ApiClient newApiClient() {
-        ApiClient client = new ApiClient();
-        client.setBasePath(mcProperties.getBasePath());
-        client.setDebugging(true);
-        client.setReadTimeout(40000);
-        return client;
+            okHttpClientBuilder.addInterceptor(new OkHttpOAuth1Interceptor(consumerKey, loadSigningKey()));
+            return cryptoApiClient.setHttpClient(okHttpClientBuilder.build());
+        } catch (Exception e) {
+            log.error("Failed to initialize OAuth1 CryptoApiClient: {}", e.getMessage());
+        }
+        return cryptoApiClient;
     }
 }

--- a/src/main/java/com/mastercard/developer/config/ApiClientOAuth2Configuration.java
+++ b/src/main/java/com/mastercard/developer/config/ApiClientOAuth2Configuration.java
@@ -1,0 +1,163 @@
+package com.mastercard.developer.config;
+
+import com.mastercard.developer.crypto.interceptor.OkHttpJweEncryptionInterceptor;
+import com.mastercard.developer.encryption.JweConfig;
+import com.mastercard.developer.encryption.JweConfigBuilder;
+import com.mastercard.developer.oauth2.config.OAuth2Config;
+import com.mastercard.developer.oauth2.config.SecurityProfile;
+import com.mastercard.developer.oauth2.core.access_token.InMemoryAccessTokenStore;
+import com.mastercard.developer.oauth2.core.dpop.DPoPKeyProvider;
+import com.mastercard.developer.oauth2.core.dpop.StaticDPoPKeyProvider;
+import com.mastercard.developer.oauth2.core.scope.StaticScopeResolver;
+import com.mastercard.developer.oauth2.http.okhttp3.OAuth2Interceptor;
+import com.mastercard.developer.utils.EncryptionUtils;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.OkHttpClient;
+import okhttp3.logging.HttpLoggingInterceptor;
+import org.openapitools.client.ApiClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+
+import java.net.URL;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.SecureRandom;
+import java.security.cert.Certificate;
+import java.security.spec.ECGenParameterSpec;
+import java.time.Duration;
+import java.util.Set;
+
+@Primary
+@Profile("oauth2")
+@Slf4j
+@Configuration
+public class ApiClientOAuth2Configuration extends BaseApiClientConfiguration {
+
+    @Value("${mastercard.api.oauth2.client.id}")
+    private String clientId;
+
+    @Value("${mastercard.api.oauth2.kid}")
+    private String kid;
+
+    @Value("${mastercard.api.oauth2.token.url}")
+    private String tokenUrl;
+
+    @Value("${mastercard.api.oauth2.issuer.url}")
+    private String issuerUrl;
+
+    @Value("${mastercard.api.oauth2.scope:promotions-digital-enablement:read}")
+    private String scope;
+
+    @Value("${mastercard.api.encryption-certificate-file-path:#{null}}")
+    private String encryptionCertificateFilePath;
+
+    @Value("${mastercard.api.decryption-key-file-path:#{null}}")
+    private String decryptionKeyFilePath;
+
+    @Value("${mastercard.api.decryption-key-alias:#{null}}")
+    private String decryptionKeyAlias;
+
+    @Value("${mastercard.api.decryption-keystore-password:#{null}}")
+    private String decryptionKeystorePassword;
+
+    @Override
+    public ApiClient getApiClient() {
+        return createNewApiClient();
+    }
+
+    @Override
+    public ApiClient createNewApiClient() {
+        ApiClient apiClient = buildBaseApiClient();
+        try {
+            OAuth2Config oauth2Config = OAuth2Config.builder()
+                    .securityProfile(SecurityProfile.FAPI2SP_PRIVATE_KEY_DPOP)
+                    .clientId(clientId)
+                    .clientKey(loadSigningKey())
+                    .tokenEndpoint(new URL(tokenUrl))
+                    .issuer(new URL(issuerUrl))
+                    .kid(kid)
+                    .accessTokenStore(new InMemoryAccessTokenStore())
+                    .scopeResolver(new StaticScopeResolver(Set.of(scope.split(","))))
+                    .dpopKeyProvider(initDpopKeyProvider())
+                    .clockSkewTolerance(Duration.ofSeconds(60))
+                    .build();
+
+            OkHttpClient.Builder okHttpClientBuilder = buildHttpClientBuilder(apiClient);
+            okHttpClientBuilder.addInterceptor(new OAuth2Interceptor(oauth2Config));
+
+            var loggingInterceptor = new HttpLoggingInterceptor(log::info);
+            loggingInterceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
+            okHttpClientBuilder.addInterceptor(loggingInterceptor);
+
+            return apiClient.setHttpClient(okHttpClientBuilder.build());
+        } catch (Exception e) {
+            log.error("Failed to initialize OAuth2 ApiClient", e);
+        }
+        return apiClient;
+    }
+
+    @Bean
+    @Primary
+    public ApiClient apiClient() {
+        return createNewApiClient();
+    }
+
+    @Bean
+    public ApiClient cryptoApiClient() {
+        ApiClient apiClient = buildBaseApiClient();
+        try {
+            OAuth2Config oauth2Config = OAuth2Config.builder()
+                    .securityProfile(SecurityProfile.FAPI2SP_PRIVATE_KEY_DPOP)
+                    .clientId(clientId)
+                    .clientKey(loadSigningKey())
+                    .tokenEndpoint(new URL(tokenUrl))
+                    .issuer(new URL(issuerUrl))
+                    .kid(kid)
+                    .accessTokenStore(new InMemoryAccessTokenStore())
+                    .scopeResolver(new StaticScopeResolver(Set.of(scope.split(","))))
+                    .dpopKeyProvider(initDpopKeyProvider())
+                    .clockSkewTolerance(Duration.ofSeconds(60))
+                    .build();
+
+            OkHttpClient.Builder okHttpClientBuilder = buildHttpClientBuilder(apiClient);
+
+            // Add JWE encryption if configured
+            if (encryptionCertificateFilePath != null && decryptionKeyFilePath != null) {
+                Certificate certificate = EncryptionUtils.loadEncryptionCertificate(encryptionCertificateFilePath);
+                PrivateKey decryptionKey = EncryptionUtils.loadDecryptionKey(
+                        decryptionKeyFilePath, decryptionKeyAlias, decryptionKeystorePassword);
+
+                JweConfig jweConfig = JweConfigBuilder.aJweEncryptionConfig()
+                        .withEncryptionCertificate(certificate)
+                        .withEncryptionPath("$", "$")
+                        .withEncryptedValueFieldName("encryptedPayload")
+                        .withDecryptionKey(decryptionKey)
+                        .build();
+
+                okHttpClientBuilder.addInterceptor(new OkHttpJweEncryptionInterceptor(jweConfig));
+            }
+
+            okHttpClientBuilder.addInterceptor(new OAuth2Interceptor(oauth2Config));
+
+            var loggingInterceptor = new HttpLoggingInterceptor(log::info);
+            loggingInterceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
+            okHttpClientBuilder.addInterceptor(loggingInterceptor);
+
+            return apiClient.setHttpClient(okHttpClientBuilder.build());
+        } catch (Exception e) {
+            log.error("Failed to initialize OAuth2 CryptoApiClient", e);
+        }
+        return apiClient;
+    }
+
+    private DPoPKeyProvider initDpopKeyProvider() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC");
+        kpg.initialize(new ECGenParameterSpec("secp256r1"), new SecureRandom());
+        KeyPair kp = kpg.generateKeyPair();
+        return new StaticDPoPKeyProvider(kp);
+    }
+}

--- a/src/main/java/com/mastercard/developer/config/ApiClientProvider.java
+++ b/src/main/java/com/mastercard/developer/config/ApiClientProvider.java
@@ -1,0 +1,8 @@
+package com.mastercard.developer.config;
+
+import org.openapitools.client.ApiClient;
+
+public interface ApiClientProvider {
+    ApiClient getApiClient();
+    ApiClient createNewApiClient();
+}

--- a/src/main/java/com/mastercard/developer/config/ApiClientResolver.java
+++ b/src/main/java/com/mastercard/developer/config/ApiClientResolver.java
@@ -1,0 +1,35 @@
+package com.mastercard.developer.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.openapitools.client.ApiClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+
+@Component
+@Slf4j
+public class ApiClientResolver {
+
+    @Autowired
+    private ApiClientProvider apiClientProvider;
+
+    @Autowired
+    private Environment environment;
+
+    public ApiClient resolveApiClient() {
+        String[] activeProfiles = environment.getActiveProfiles();
+        log.info("Active profiles: {}", Arrays.toString(activeProfiles));
+
+        if (Arrays.asList(activeProfiles).contains("oauth2")) {
+            log.info("Resolving ApiClient using OAuth2 configuration");
+        } else if (Arrays.asList(activeProfiles).contains("oauth1")) {
+            log.info("Resolving ApiClient using OAuth1 configuration");
+        } else {
+            log.warn("No recognized auth profile active. Defaulting to available ApiClientProvider.");
+        }
+
+        return apiClientProvider.createNewApiClient();
+    }
+}

--- a/src/main/java/com/mastercard/developer/config/BaseApiClientConfiguration.java
+++ b/src/main/java/com/mastercard/developer/config/BaseApiClientConfiguration.java
@@ -2,11 +2,15 @@ package com.mastercard.developer.config;
 
 import com.mastercard.developer.utils.AuthenticationUtils;
 import lombok.extern.slf4j.Slf4j;
+import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
 import org.openapitools.client.ApiClient;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.io.IOException;
 import java.security.PrivateKey;
 
 @Slf4j
@@ -25,6 +29,9 @@ public abstract class BaseApiClientConfiguration implements ApiClientProvider {
     @Value("${mastercard.api.key-file-path:#{null}}")
     protected String signingKeyPkcs12Path;
 
+    @Value("${mastercard.api.downstream-route:#{null}}")
+    protected String downstreamRoute;
+
     protected ApiClient buildBaseApiClient() {
         ApiClient apiClient = new ApiClient();
         apiClient.setBasePath(basePath);
@@ -38,6 +45,26 @@ public abstract class BaseApiClientConfiguration implements ApiClientProvider {
     }
 
     protected OkHttpClient.Builder buildHttpClientBuilder(ApiClient apiClient) {
-        return apiClient.getHttpClient().newBuilder();
+        OkHttpClient.Builder builder = apiClient.getHttpClient().newBuilder();
+        if (downstreamRoute != null && !downstreamRoute.isEmpty()) {
+            builder.addInterceptor(new DownstreamRouteInterceptor(downstreamRoute));
+        }
+        return builder;
+    }
+
+    private static class DownstreamRouteInterceptor implements Interceptor {
+        private final String route;
+
+        DownstreamRouteInterceptor(String route) {
+            this.route = route;
+        }
+
+        @Override
+        public Response intercept(Chain chain) throws IOException {
+            Request request = chain.request().newBuilder()
+                    .addHeader("downstream-route", route)
+                    .build();
+            return chain.proceed(request);
+        }
     }
 }

--- a/src/main/java/com/mastercard/developer/config/BaseApiClientConfiguration.java
+++ b/src/main/java/com/mastercard/developer/config/BaseApiClientConfiguration.java
@@ -1,0 +1,43 @@
+package com.mastercard.developer.config;
+
+import com.mastercard.developer.utils.AuthenticationUtils;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.OkHttpClient;
+import org.openapitools.client.ApiClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.PrivateKey;
+
+@Slf4j
+@Component
+public abstract class BaseApiClientConfiguration implements ApiClientProvider {
+
+    @Value("${mastercard.api.base-path}")
+    protected String basePath;
+
+    @Value("${mastercard.api.keystore-alias}")
+    protected String signingKeyAlias;
+
+    @Value("${mastercard.api.keystore-password}")
+    protected String signingKeyPassword;
+
+    @Value("${mastercard.api.key-file-path:#{null}}")
+    protected String signingKeyPkcs12Path;
+
+    protected ApiClient buildBaseApiClient() {
+        ApiClient apiClient = new ApiClient();
+        apiClient.setBasePath(basePath);
+        apiClient.setDebugging(true);
+        apiClient.setReadTimeout(40000);
+        return apiClient;
+    }
+
+    protected PrivateKey loadSigningKey() throws Exception {
+        return AuthenticationUtils.loadSigningKey(signingKeyPkcs12Path, signingKeyAlias, signingKeyPassword);
+    }
+
+    protected OkHttpClient.Builder buildHttpClientBuilder(ApiClient apiClient) {
+        return apiClient.getHttpClient().newBuilder();
+    }
+}

--- a/src/main/java/com/mastercard/developer/config/MastercardProperties.java
+++ b/src/main/java/com/mastercard/developer/config/MastercardProperties.java
@@ -4,10 +4,13 @@ import com.mastercard.developer.exception.ServiceException;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.core.env.Environment;
 import org.springframework.core.io.Resource;
 
 import javax.annotation.PostConstruct;
+import java.util.Arrays;
 
 @Getter
 @Setter
@@ -34,13 +37,22 @@ public class MastercardProperties {
 
     private String decryptionKeystorePassword;
 
+    @Autowired
+    private Environment environment;
+
     @PostConstruct
     public void initialize() throws ServiceException {
-        if (null == keyFile || StringUtils.isEmpty(consumerKey)) {
-            throw new ServiceException(".p12 file or consumerKey does not exist, please add details in application.properties");
-        }
-        if (null == encryptionCertificateFile || null == decryptionKeyFile) {
-            throw new ServiceException("Key parameters required for encryption/decryption are not set, please add details in application.properties");
+        String[] activeProfiles = environment.getActiveProfiles();
+        boolean isOAuth2 = Arrays.asList(activeProfiles).contains("oauth2");
+
+        // OAuth2 mode doesn't require consumer key or .p12 via Resource binding
+        if (!isOAuth2) {
+            if (null == keyFile || StringUtils.isEmpty(consumerKey)) {
+                throw new ServiceException(".p12 file or consumerKey does not exist, please add details in application.properties");
+            }
+            if (null == encryptionCertificateFile || null == decryptionKeyFile) {
+                throw new ServiceException("Key parameters required for encryption/decryption are not set, please add details in application.properties");
+            }
         }
     }
 }

--- a/src/main/resources/Promotions_Digital_Enablement-api-spec.yaml
+++ b/src/main/resources/Promotions_Digital_Enablement-api-spec.yaml
@@ -1981,7 +1981,7 @@ components:
             - COUNT - Transaction count
             - SPEND - Transaction spend amount
             - RATE -  Accumulated tiering value
-          example: "AMOUNT"
+          example: "SPEND"
         fieldType:
           type: string
           description: |

--- a/src/main/resources/Promotions_Digital_Enablement-api-spec.yaml
+++ b/src/main/resources/Promotions_Digital_Enablement-api-spec.yaml
@@ -1781,6 +1781,24 @@ components:
           format: date-time
           description: The time when the status was updated.
           example: "2020-06-05T15:19:31.827Z"
+        beginDateTime:
+          type: string
+          format: date-time
+          description: Promotion begin date and time.
+          example: "2023-02-01T15:15:31.827Z"
+        endDateTime:
+          type: string
+          format: date-time
+          description: Promotion end date and time.
+          example: "2023-12-31T23:59:59.000Z"
+        scoringType:
+          type: string
+          description: The scoring type of the promotion.
+          example: "TRANSACTION"
+        ranked:
+          type: boolean
+          description: Indicates if the promotion is ranked.
+          example: false
     OptIn:
       type: object
       properties:

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,7 +3,7 @@
 ##################################################################
 
 # This is the static field, referring to sandbox endpoint
-mastercard.api.base-path=https://stage.api.mastercard.com/loyalty/rewards
+mastercard.api.base-path=https://sandbox.api.mastercard.com/loyalty/rewards
 
 ##################################################################
 # Active Spring Profile
@@ -52,10 +52,10 @@ mastercard.api.oauth2.client.id=
 mastercard.api.oauth2.kid=
 
 # Token endpoint URL where access tokens are requested.
-mastercard.api.oauth2.token.url=https://stage.api.mastercard.com/oauth/token
+mastercard.api.oauth2.token.url=https://sandbox.api.mastercard.com/oauth/token
 
 # Issuer URL used to validate the OAuth 2.0 authorization server identity.
-mastercard.api.oauth2.issuer.url=https://stage.api.mastercard.com
+mastercard.api.oauth2.issuer.url=https://sandbox.api.mastercard.com
 
 # OAuth 2.0 scopes (comma-separated)
 mastercard.api.oauth2.scope=rewards-api-gateway:promotions-digital-enablement_read

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,7 +13,7 @@ mastercard.api.base-path=https://stage.api.mastercard.com/loyalty/rewards
 # Options:
 #   oauth1  - Uses OAuth 1.0a signing (OkHttpOAuth1Interceptor)
 #   oauth2  - Uses OAuth 2.0 with DPoP (OAuth2Interceptor) [default]
-spring.profiles.active=oauth2
+spring.profiles.active=oauth1
 
 ##################################################################
 # Signing Key Configuration (OAuth1 & OAuth2)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,7 +6,31 @@
 mastercard.api.base-path=https://sandbox.api.mastercard.com/loyalty/rewards
 
 ##################################################################
-# Authentication
+# Active Spring Profile
+##################################################################
+
+# Determines the authentication strategy used at runtime.
+# Options:
+#   oauth1  - Uses OAuth 1.0a signing (OkHttpOAuth1Interceptor)
+#   oauth2  - Uses OAuth 2.0 with DPoP (OAuth2Interceptor) [default]
+spring.profiles.active=oauth2
+
+##################################################################
+# Signing Key Configuration (OAuth1 & OAuth2)
+##################################################################
+
+# Path to the PKCS12 keystore (.p12) file used for request signing.
+# e.g: src/main/resources/sandbox-cert.p12
+mastercard.api.key-file-path=
+
+# key alias. Default key alias for sandbox is "keyalias" (without quotes).
+mastercard.api.keystore-alias=keyalias
+
+# keystore password. Default keystore password for sandbox project is "keystorepassword" (without quotes).
+mastercard.api.keystore-password=keystorepassword
+
+##################################################################
+# Authentication - OAuth 1.0a (used when spring.profiles.active=oauth1)
 ##################################################################
 
 # Please refer to https://developer.mastercard.com for details
@@ -17,11 +41,24 @@ mastercard.api.key-file=
 # e.g. ylk2Y6cDCk9lDnLxl06SE7ovx2q3eoWLRBMKxTvF2b3c2228!248b2788cfd74ec8b0b8b3fd1eeb93960000000000000000
 mastercard.api.consumer-key=
 
-# key alias. Default key alias for sandbox is "keyalias" (without quotes).
-mastercard.api.keystore-alias=keyalias
+##################################################################
+# OAuth 2.0 Configuration (used when spring.profiles.active=oauth2)
+##################################################################
 
-# keystore password. Default keystore password for sandbox project is "keystorepassword" (without quotes).
-mastercard.api.keystore-password=keystorepassword
+# OAuth 2.0 client ID registered on the Mastercard Developer portal.
+mastercard.api.oauth2.client.id=
+
+# Key ID (kid) associated with the client's signing key, used in JWT headers.
+mastercard.api.oauth2.kid=
+
+# Token endpoint URL where access tokens are requested.
+mastercard.api.oauth2.token.url=https://sandbox.api.mastercard.com/oauth/token
+
+# Issuer URL used to validate the OAuth 2.0 authorization server identity.
+mastercard.api.oauth2.issuer.url=https://sandbox.api.mastercard.com
+
+# OAuth 2.0 scopes (comma-separated)
+mastercard.api.oauth2.scope=promotions-digital-enablement:read
 
 ##################################################################
 # Encryption and Decryption
@@ -31,16 +68,20 @@ mastercard.api.keystore-password=keystorepassword
 # Copy .pem file in src/main/resources and set value as classpath:PromotionDigitalEnablementClientEnc.pem
 mastercard.api.encryption-certificate-file=
 
+# File path for encryption certificate (used in OAuth2 mode)
+mastercard.api.encryption-certificate-file-path=
+
 # Decryption key file
 # Copy .p12 file in src/main/resources and set value as classpath:keyalias-encryption-mc.p12
 mastercard.api.decryption-key-file=
 
+# File path for decryption key (used in OAuth2 mode)
+mastercard.api.decryption-key-file-path=
+
 # Decryption key alias.
-# Note: Always keep your private signing keys safe, in a password-protected or hardware key store!
 mastercard.api.decryption-key-alias=
 
 # Decryption keystore password.
-# Note: Always keep your private signing keys safe, in a password-protected or hardware key store!
 mastercard.api.decryption-keystore-password=
 
 spring.mvc.pathmatch.matching-strategy=ant_path_matcher

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,7 +3,7 @@
 ##################################################################
 
 # This is the static field, referring to sandbox endpoint
-mastercard.api.base-path=https://sandbox.api.mastercard.com/loyalty/rewards
+mastercard.api.base-path=https://stage.api.mastercard.com/loyalty/rewards
 
 ##################################################################
 # Active Spring Profile
@@ -27,7 +27,7 @@ mastercard.api.key-file-path=
 mastercard.api.keystore-alias=keyalias
 
 # keystore password. Default keystore password for sandbox project is "keystorepassword" (without quotes).
-mastercard.api.keystore-password=keystorepassword
+mastercard.api.keystore-password=
 
 ##################################################################
 # Authentication - OAuth 1.0a (used when spring.profiles.active=oauth1)
@@ -52,13 +52,13 @@ mastercard.api.oauth2.client.id=
 mastercard.api.oauth2.kid=
 
 # Token endpoint URL where access tokens are requested.
-mastercard.api.oauth2.token.url=https://sandbox.api.mastercard.com/oauth/token
+mastercard.api.oauth2.token.url=https://stage.api.mastercard.com/oauth/token
 
 # Issuer URL used to validate the OAuth 2.0 authorization server identity.
-mastercard.api.oauth2.issuer.url=https://sandbox.api.mastercard.com
+mastercard.api.oauth2.issuer.url=https://stage.api.mastercard.com
 
 # OAuth 2.0 scopes (comma-separated)
-mastercard.api.oauth2.scope=promotions-digital-enablement:read
+mastercard.api.oauth2.scope=rewards-api-gateway:promotions-digital-enablement_read
 
 ##################################################################
 # Encryption and Decryption
@@ -69,7 +69,7 @@ mastercard.api.oauth2.scope=promotions-digital-enablement:read
 mastercard.api.encryption-certificate-file=
 
 # File path for encryption certificate (used in OAuth2 mode)
-mastercard.api.encryption-certificate-file-path=
+mastercard.api.encryption-certificate-file-path=src/main/resources/encryption-key.pem
 
 # Decryption key file
 # Copy .p12 file in src/main/resources and set value as classpath:keyalias-encryption-mc.p12
@@ -79,7 +79,7 @@ mastercard.api.decryption-key-file=
 mastercard.api.decryption-key-file-path=
 
 # Decryption key alias.
-mastercard.api.decryption-key-alias=
+mastercard.api.decryption-key-alias=keyalias
 
 # Decryption keystore password.
 mastercard.api.decryption-keystore-password=


### PR DESCRIPTION
- Add ApiClientOAuth2Configuration with FAPI2SP_PRIVATE_KEY_DPOP profile
- Add BaseApiClientConfiguration abstract class for shared key loading
- Add ApiClientProvider interface and ApiClientResolver component
- Refactor ApiClientConfiguration to profile-based (oauth1/oauth2)
- Update MastercardProperties to conditionally validate per profile
- Add oauth2-client-java dependency and OAuth2 properties
- Default active profile set to oauth2

Ticket: G1302-23023